### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/copilot-rpc.js
+++ b/src/copilot-rpc.js
@@ -15,6 +15,45 @@ const COPILOT_RPC = (() => {
 
   const MAX_LOG_CHARS = 2048;
 
+  function redactSensitive(value) {
+    try {
+      if (value === null || typeof value !== "object") {
+        return value;
+      }
+      const SENSITIVE_KEYS = new Set([
+        "apikey",
+        "api_key",
+        "authorization",
+        "auth",
+        "password",
+        "token",
+        "secret",
+      ]);
+      const redactObject = (obj) => {
+        if (obj === null || typeof obj !== "object") {
+          return obj;
+        }
+        if (Array.isArray(obj)) {
+          return obj.map(redactObject);
+        }
+        const clone = {};
+        for (const [k, v] of Object.entries(obj)) {
+          if (SENSITIVE_KEYS.has(k.toLowerCase())) {
+            clone[k] = "[REDACTED]";
+          } else if (v && typeof v === "object") {
+            clone[k] = redactObject(v);
+          } else {
+            clone[k] = v;
+          }
+        }
+        return clone;
+      };
+      return redactObject(value);
+    } catch {
+      return value;
+    }
+  }
+
   function truncateForLog(value) {
     try {
       const serialized = typeof value === "string" ? value : JSON.stringify(value);
@@ -31,7 +70,7 @@ const COPILOT_RPC = (() => {
 
   async function apiCall(path, body = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
     const url = `${_baseUrl}${path}`;
-    console.log(`[RPC] → POST ${path}`, truncateForLog(body));
+    console.log(`[RPC] → POST ${path}`, truncateForLog(redactSensitive(body)));
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);


### PR DESCRIPTION
Potential fix for [https://github.com/payton-chou-ms/browser-ext-for-iq-agent/security/code-scanning/1](https://github.com/payton-chou-ms/browser-ext-for-iq-agent/security/code-scanning/1)

In general, to fix this class of issue, ensure that any logging of request/response payloads either (a) omits sensitive fields entirely, or (b) redacts them before logging. Length truncation is not sufficient; the underlying secret values must not be visible in the log output.

For this specific code, the least intrusive fix is to keep the existing `truncateForLog` behavior for non-sensitive data while adding a redaction step that removes or masks known sensitive keys (such as `apiKey`) from objects before they are logged. We can do this by introducing a small helper, e.g. `redactSensitive`, that clones objects shallowly and replaces values for keys like `apiKey`, `password`, `token`, `Authorization`, etc., and then use that helper in `apiCall` when logging the request body (line 34). We should avoid changing how the body is actually sent to `fetch` so behavior remains the same; we only alter what is passed to `console.log`.

Concretely:

- In `src/copilot-rpc.js`, above `truncateForLog`, define a `redactSensitive` function that:
  - If given a non-object, returns it unchanged.
  - If given an object, shallow-copies it and for each property name matching a small set of sensitive key names (case-insensitive) replaces the value with a placeholder like `"[REDACTED]"`.
- Optionally, handle nested objects or arrays minimally (e.g., if the value is an object, recurse into it); however, for preserving existing functionality with minimal change, even a shallow redaction of top-level fields is an improvement and is sufficient to address the flagged `apiKey` field in this code path.
- Update the logging line in `apiCall` (line 34) to call `truncateForLog(redactSensitive(body))` instead of `truncateForLog(body)`.
- Leave all other logging (e.g., responses) as-is unless you also want to preemptively avoid logging secrets that may appear in responses; since the alert is specific to the request body containing `apiKey`, we will focus on that.

No new external packages are needed; this can be done with plain JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
