### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/lib/chat.js
+++ b/src/lib/chat.js
@@ -164,6 +164,20 @@
     "The user's current browser tab context is provided in <browser_context> tags with each message.",
   ].join(" ");
 
+  // Helper to safely set message content, avoiding raw innerHTML on untrusted text.
+  function setSafeContent(element, formattedText) {
+    const utils = root.utils || {};
+    const sanitizeHtml = utils.sanitizeHtml;
+
+    if (typeof sanitizeHtml === "function") {
+      // Use the host application's HTML sanitizer if available.
+      element.innerHTML = sanitizeHtml(formattedText || "");
+    } else {
+      // Fallback: treat as plain text to avoid interpreting HTML.
+      element.textContent = formattedText || "";
+    }
+  }
+
   // ── DOM Helpers ──
   function createMessage(role, text) {
     const utils = root.utils || {};
@@ -182,7 +196,8 @@
     // Content wrapper
     const content = document.createElement("div");
     content.className = "msg-content";
-    content.innerHTML = formatText(role === "bot" ? formatNewsResponse(text) : text);
+    const formatted = formatText(role === "bot" ? formatNewsResponse(text) : text);
+    setSafeContent(content, formatted);
     bubble.appendChild(content);
 
     // Add action bar for bot messages


### PR DESCRIPTION
Potential fix for [https://github.com/payton-chou-ms/browser-ext-for-iq-agent/security/code-scanning/5](https://github.com/payton-chou-ms/browser-ext-for-iq-agent/security/code-scanning/5)

In general, to fix “DOM text reinterpreted as HTML” problems, avoid feeding untrusted strings into `.innerHTML` (or other HTML-parsing sinks) unless the content is strictly sanitized. Instead, assign to `.textContent` or construct the DOM tree using element creation APIs. If some formatting (like basic Markdown) is desired, run the string through a robust sanitizer/renderer that outputs safe HTML.

For this specific code, the most targeted fix is to change `createMessage` so that it does not call `.innerHTML` directly on the formatted text. Since `createMessage` is a central helper used for both user and bot messages, fixing it will address all alert variants that end at line 185. We will:

1. Introduce a small helper `setSafeContent(element, htmlString)` inside `chat.js` that:
   - Accepts the string returned by `formatText(...)`.
   - If `utils.sanitizeHtml` exists, uses it to sanitize the string before assigning to `innerHTML`.
   - Otherwise, treats the string as plain text and assigns it via `textContent`, preventing any HTML interpretation.
2. Replace the direct assignment to `content.innerHTML` inside `createMessage` with a call to `setSafeContent`.

This preserves existing functionality when a site-specific `utils.sanitizeHtml` (or an equivalent formatter) is present (for example, if they rely on HTML for formatting bot responses), while guaranteeing that in the absence of such a sanitizer (the current fallback case that CodeQL analyzes), untrusted data is not interpreted as HTML.

Changes are limited to `src/lib/chat.js` within the shown snippet. No new external dependencies are required; we leverage the existing `root.utils` namespace and optional `sanitizeHtml`-style function when present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
